### PR TITLE
Ch3 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # dw4r-emotracker
 EmoTracker package for Dragon Warrior 4 Randomizer
+
+To install manually, place the release zip file in the EmoTracker/packs folder.

--- a/locations.json
+++ b/locations.json
@@ -1110,7 +1110,7 @@
                 "sections": [
                     {
                         "name": "Top-right basement Dresser",
-                        "access_rules": [ "$inCh5,gascanister" ],
+                        "access_rules": [ "$inCh5,boat,gascanister" ],
 
                         "item_count": 1
                     }
@@ -1130,7 +1130,7 @@
                 "sections": [
                     {
                         "name": "Dungeon Treasures",
-                        "access_rules": [ "$inCh5,gascanister" ],
+                        "access_rules": [ "$inCh5,boat,gascanister" ],
 
                         "item_count": 2
                     }
@@ -1150,7 +1150,7 @@
                 "sections": [
                     {
                         "name": "Dungeon Treasures",
-                        "access_rules": [ "$inCh5,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
+                        "access_rules": [ "$inCh5,boat,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
 
                         "item_count": 5
                     }
@@ -1170,7 +1170,7 @@
                 "sections": [
                     {
                         "name": "Dresser on middle floor, next to World Dew NPC",
-                        "access_rules": [ "$inCh5,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
+                        "access_rules": [ "$inCh5,boat,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
 
                         "item_count": 1
                     }
@@ -1190,7 +1190,7 @@
                 "sections": [
                     {
                         "name": "Dungeon Treasures",
-                        "access_rules": [ "$inCh5,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
+                        "access_rules": [ "$inCh5,boat,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
 
                         "item_count": 13
                     }
@@ -1217,7 +1217,7 @@
                 "sections": [
                     {
                         "name": "Long Trek through the Marsh",
-                        "access_rules": [ "$inCh5,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
+                        "access_rules": [ "$inCh5,boat,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
 
                         "item_count": 1
                     }
@@ -1237,7 +1237,7 @@
                 "sections": [
                     {
                         "name": "Dungeon Treasures",
-                        "access_rules": [ "$inCh5,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
+                        "access_rules": [ "$inCh5,boat,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
 
                         "item_count": 1
                     }
@@ -1257,7 +1257,7 @@
                 "sections": [
                     {
                         "name": "Dungeon Treasures",
-                        "access_rules": [ "$inCh5,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
+                        "access_rules": [ "$inCh5,boat,gascanister,zenithianarmor,zenithianshield,zenithiansword,zenithianhelm" ],
 
                         "item_count": 4
                     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-    "name": "Dragon Warrior 4 Randomizer Tracker - v0.1",
+    "name": "Dragon Warrior 4 Randomizer Tracker - v0.2",
     "game_name": "Dragon Warrior 4",
     "platform": "NES",
     "game_variant": "v0.13.2",
-    "package_version": "0.1",
+    "package_version": "0.2",
     "package_uid": "dw4rt_polantaris",
     "author": "Polantaris"
 }

--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -41,7 +41,7 @@ end
 function canAccessEndor()
     if Tracker:ProviderCountForCode("ch2complete") <= 0 and Tracker:ProviderCountForCode("birdsongnectar") > 0 then
         return 1
-    elseif Tracker:ProviderCountForCode("ch3complete") <= 0 and Tracker:ProviderCountForCode("bridgebuilt") > 0 then
+    elseif Tracker:ProviderCountForCode("ch3complete") <= 0 and Tracker:ProviderCountForCode("bridgesbuilt") > 0 then
         return 1
     elseif Tracker:ProviderCountForCode("ch4complete") > 0 then
         return 1


### PR DESCRIPTION
Endor locations were bugged in Ch.3 due to a misnamed variable in the function.

Also added boat requirements for anything that requires the gas canister, as you cannot use the gas canister without the boat.